### PR TITLE
Remove delete-after option from rsync command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,6 @@ jobs:
             --itemize-changes \
             --stats \
             --timeout=120 \
-            --delete-after \
             ${{ steps.rsync-excludes.outputs.excludes }} \
             -e "ssh -p ${{ secrets.remote_port || '22' }}" \
             ./ ${{ secrets.remote_user }}@${{ secrets.remote_host }}:${{ secrets.remote_path }}/


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration. The change involves removing the `--delete-after` option from the `rsync` command in the `.github/workflows/deploy.yml` file, which affects how files are synchronized during deployment.